### PR TITLE
Moved the cluster plugin from cloud9 and adapted it slightly

### DIFF
--- a/plugins/architect.cluster/README.md
+++ b/plugins/architect.cluster/README.md
@@ -1,0 +1,23 @@
+`architect.cluster`
+===================
+
+This plugin wraps the node.js cluster API as an architect plugin.
+
+Usage
+-----
+
+In your architect config:
+
+    {
+        packagePath: "architect/plugins/architect.cluster",
+        pluginBasePath: __dirname + "../plugins",
+        numWorkers: 16,
+        workerConfig: require("./worker"),
+        // This one is optional:
+        masterConfig: require("./master")
+    }
+    
+This will spin up 16 worker processes and one master process that manages those
+workers, if you specify `masterConfig`, this architect config will be loaded for
+the cluster master process. The `pluginBasePath` should point to the root path
+of your plugin directory to make plugins with relative paths ("./bla.bla") work.

--- a/plugins/architect.cluster/cluster-plugin.js
+++ b/plugins/architect.cluster/cluster-plugin.js
@@ -1,0 +1,40 @@
+var assert = require("assert");
+var cluster = require("cluster");
+var architect = require("../../architect");
+
+module.exports = function startup(options, imports, register) {
+    assert(options.pluginBaseDir, "Option 'pluginBaseDir' is required");
+    assert(options.workerConfig, "Option 'workerConfig' is required");
+    assert(options.numWorkers, "Option 'numWorkers' is required");
+
+    var numWorkers = options.numWorkers;
+
+    if (cluster.isMaster) {
+        // Fork each worker onto its own thread
+        for (var i = 0; i < numWorkers; i++) {
+            cluster.fork();
+        }
+
+        // When a worker dies, fork a new one
+        cluster.on('death', function(worker) {
+            cluster.fork();
+        });
+
+        if (options.masterConfig) {
+            var plugins = architect.resolveConfig(options.masterConfig, options.pluginBaseDir);
+            architect.createApp(plugins, onCreateApp);
+        }
+    }
+    else {
+        // If the worker is not the master process, run the worker config
+        var plugins = architect.resolveConfig(options.workerConfig, options.pluginBaseDir);
+        architect.createApp(plugins, onCreateApp);
+    }
+
+    function onCreateApp(err) {
+        if (err)
+            throw err;
+    }
+
+    register(null, {});
+};

--- a/plugins/architect.cluster/package.json
+++ b/plugins/architect.cluster/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "architect.cluster",
+    "version": "0.0.1",
+    "main": "cluster-plugin.js",
+    "plugin": {}
+}


### PR DESCRIPTION
to be more generic.

I think we can have the policy of putting plug-ins that wrap node.js builtin APIs in the architect main repo, and all others in separate repos.

@creationix or @sergi or @cadorn 
