### PR TITLE
parent path resolution breaks in windows

### DIFF
--- a/architect.js
+++ b/architect.js
@@ -184,7 +184,7 @@ if (typeof module === "object") (function () {
                     cache[packagePath] = newPath;
                     return newPath;
                 }
-                base = base.substr(0, base.lastIndexOf("/"));
+                base = resolve(base, '..');
             }
         }
         var err = new Error("Can't find '" + packagePath + "' relative to '" + originalBase + "'");
@@ -239,7 +239,7 @@ if (typeof module === "object") (function () {
                         return callback(null, newPath);
                     });
                 } else {
-                    tryNext(base.substr(0, base.lastIndexOf("/")));
+                    tryNext(resolve(base, '..'));
                 }
             });
         }


### PR DESCRIPTION
parent path resolution breaks in windows 

Using `/` on 'resolved' path in windows doesn't work as path is like 'c:\path\to\base'

replace `base.substr(0, base.lastIndexOf("/"))` with `resolve(base, '..')`
