### PR TITLE
hub on callback function bind to app

### DIFF
--- a/architect.js
+++ b/architect.js
@@ -410,6 +410,7 @@ function Architect(config) {
     var services = app.services = {
         hub: {
             on: function (name, callback) {
+                if(typeof(callback) == "function") callback = callback.bind(app);
                 app.on(name, callback);
             }
         }


### PR DESCRIPTION
it felt convenient to have the "hub" service 'on' function argument 'callback' to inherit architect

``` js
hub.on("ready",function(){
   var app = this;
});

hub.on("plugin",function(plugin){
   var app = this;
});

hub.on("service",function(name, service){
   var app = this;
});
```
