### PR TITLE
fix exit condition in loop, to prevent infinite loop

### DIFF
--- a/architect.js
+++ b/architect.js
@@ -200,7 +200,7 @@ if (typeof module === "object") (function () {
             }
         }
         else {
-            while (base) {
+            while (base !== "/") {
                 newPath = resolve(base, "node_modules", packagePath);
                 if (existsSync(newPath)) {
                     newPath = realpathSync(newPath);


### PR DESCRIPTION
When trying lo load a module synchronously, and that module doesn't exist, the loader stalls in an infinite loop, as `base` is never `undefined`, `null` or `""`, even when we try to go one level higher from root.
When loading the module asynchronously, the code works, as is used `/` as exit condition [here](https://github.com/c9/architect/blob/master/architect.js#L249), instead of an empty path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes #27, that happens again as changes in #43 were reverted in #55